### PR TITLE
Fix typos

### DIFF
--- a/Rime_description.md
+++ b/Rime_description.md
@@ -246,7 +246,7 @@ erase --刪除
 </code></pre></ul>
 
 <h3>二、<code>segmentor</code></h3>
-<ul><li><code>segmentor</code>配合<code>recognizer</code>標記出<code>tag</code>。這裏會用到<code>affix_segmentor</code>和<code>abc_translator</code></li>
+<ul><li><code>segmentor</code>配合<code>recognizer</code>標記出<code>tag</code>。這裏會用到<code>affix_segmentor</code>和<code>abc_segmentor</code></li>
 <li><code>tag</code>用在<code>translator</code>、<code>reverse_lookup_filter</code>、<code>simplifier</code>中用以標定各自作用範圍</li>
 <li>如果不需要用到<code>extra_tags</code>則不需要單獨配置<code>segmentor</code></li>
 </ul>

--- a/Rime方案製作詳解.html
+++ b/Rime方案製作詳解.html
@@ -424,7 +424,7 @@ erase --刪除
 </code></pre></ul>
 
 <h3>二、<code>segmentor</code></h3>
-<ul><li><code>segmentor</code>配合<code>recognizer</code>標記出<code>tag</code>。這裏會用到<code>affix_segmentor</code>和<code>abc_translator</code></li>
+<ul><li><code>segmentor</code>配合<code>recognizer</code>標記出<code>tag</code>。這裏會用到<code>affix_segmentor</code>和<code>abc_segmentor</code></li>
 <li><code>tag</code>用在<code>translator</code>、<code>reverse_lookup_filter</code>、<code>simplifier</code>中用以標定各自作用範圍</li>
 <li>如果不需要用到<code>extra_tags</code>則不需要單獨配置<code>segmentor</code></li>
 </ul>

--- a/Rime方案製作詳解_竪排.html
+++ b/Rime方案製作詳解_竪排.html
@@ -421,7 +421,7 @@ erase --刪除
 </code></pre></ul>
 
 <h3>二、<code>segmentor</code></h3>
-<ul><li><code>segmentor</code>配合<code>recognizer</code>標記出<code>tag</code>。這裏會用到<code>affix_segmentor</code>和<code>abc_translator</code></li>
+<ul><li><code>segmentor</code>配合<code>recognizer</code>標記出<code>tag</code>。這裏會用到<code>affix_segmentor</code>和<code>abc_segmentor</code></li>
 <li><code>tag</code>用在<code>translator</code>、<code>reverse_lookup_filter</code>、<code>simplifier</code>中用以標定各自作用範圍</li>
 <li>如果不需要用到<code>extra_tags</code>則不需要單獨配置<code>segmentor</code></li>
 </ul>


### PR DESCRIPTION
I have searched the rime code base and find nothing about `abc_translator`, I guess maybe it is a typo, and it should be `abc_segmentor`.