### PR TITLE
Update 鼠鬚管介面配置指南.md

### DIFF
--- a/鼠鬚管介面配置指南.md
+++ b/鼠鬚管介面配置指南.md
@@ -16,8 +16,8 @@
 * `memorize_size`: 選定線型候選框樣式時，當候選框末端接觸屏幕邊時，是否記住候選框長度，以選免首選項位置快速變化，`true`/`false`，默認`false`
 * `translucency`: 是否添加毛玻璃背景，當背景色呈半透明時可見，`true`/`false`，默認`false`
 * `border_height`, `border_width`，邊框粗細，如未設邊框色，則僅影響佈局。可帶小數，可爲負。默認0
-* `corner_radius`: 外框圓角半徑，可帶小數。默認0
-* `hilited_corner_radius`: 候選項背景框圓角半徑，可帶小數，通常小於上一項。默認0
+* `corner_radius`: 候選框整體文字外圍留白大小，可帶小數。默認0
+* `hilited_corner_radius`: 候選項背景框留白大小，可帶小數，通常小於上一項。默認0
 * `surrounding_extra_expansion`: 非高亮（選中）候選項背景框大小縮放，`0`即與高亮框相同，負數縮小，正數放大。默認0
 * `line_spacing`: 行間距，可帶小數，可爲負。默認0
 * `spacing`: 鍵入碼區與候選項區之間的間距，可帶小數，可爲負。默認0


### PR DESCRIPTION
自己试验了一下squirrel的配置档，corner radius这个配置名称很有误导性，它定义的其实是padding，故在font_point固定的时候影响输入法框的整体大小。